### PR TITLE
feat: improve location search with dual Nominatim + Photon strategy

### DIFF
--- a/client/src/components/MapPicker.tsx
+++ b/client/src/components/MapPicker.tsx
@@ -48,11 +48,12 @@ export function MapPicker({ onPinDrop, initialLat, initialLng }: MapPickerProps)
       zoomControl: true,
     });
 
-    // OpenStreetMap tiles — free, no API key
-    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    // CartoDB Voyager tiles — free, no API key, always renders labels in English
+    L.tileLayer("https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png", {
       attribution:
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-      maxZoom: 19,
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+      subdomains: "abcd",
+      maxZoom: 20,
     }).addTo(map);
 
     // If initial coords provided, place a marker immediately


### PR DESCRIPTION
- Replace single Photon-only search with parallel Nominatim + Photon fetch
- Nominatim forward geocoding (countrycodes=ae) handles areas, neighbourhoods, streets and districts that Photon's bbox filter was missing (e.g. 'Deira', 'Al Barsha', 'JBR', 'Marina')
- Photon retained as secondary source for POI/restaurant name searches
- Results merged and deduplicated by 200m proximity radius
- Each result now shows a type badge (Neighbourhood, Mosque, Restaurant, etc.) and a sublabel (area, city) for better clarity
- Abort controller cancels in-flight requests on each new keystroke
- Minimum query length reduced from 2 to 1 char (so 'JBR' works immediately)
- Re-apply CartoDB Voyager English tile fix to MapPicker