### PR TITLE
fix: mark vite and sharp as external in server esbuild to fix Render …

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -56,7 +56,10 @@ async function buildAll() {
       "process.env.NODE_ENV": '"production"',
     },
     minify: true,
-    external: externals,
+    // vite MUST be external: it's dev-only and importing it pulls in vite.config.ts
+    // which uses import.meta.dirname — undefined in CJS format → startup crash on Render.
+    // sharp MUST be external: it uses native binaries that can't be bundled.
+    external: [...externals, "vite", "sharp"],
     logLevel: "info",
   });
 


### PR DESCRIPTION
…startup crash

import.meta.dirname is undefined in CJS output format. vite.config.ts uses it and was being bundled into the server via server/vite.ts. Marking vite as external prevents this. sharp is also external as it uses native binaries.